### PR TITLE
Fix issue in icmp ip6tables rule

### DIFF
--- a/spec/unit/recipes/frontend_permissive_ports_spec.rb
+++ b/spec/unit/recipes/frontend_permissive_ports_spec.rb
@@ -46,10 +46,16 @@ describe 'iptables-patterns::frontend_permissive_ports' do
       )
     end
 
-    it 'creates an icmp rule' do
-      expect(chef_run).to create_iptables_ng_rule('10-icmp').with(
+    it "creates separate entries for ipv4 and ipv6 icmp allow" do
+      expect(chef_run).to create_iptables_ng_rule("10-icmp-ipv4").with(
         chain: chain_name,
-        rule: '--protocol icmp --jump RETURN'
+        rule: '--protocol icmp --jump RETURN',
+        ip_version: 4
+      )
+      expect(chef_run).to create_iptables_ng_rule("10-icmp-ipv6").with(
+        chain: chain_name,
+        rule: '--protocol ipv6-icmp --jump RETURN',
+        ip_version: 6
       )
     end
 

--- a/test/integration/frontend-permissive-ports/serverspec/frontend_permissive_ports_spec.rb
+++ b/test/integration/frontend-permissive-ports/serverspec/frontend_permissive_ports_spec.rb
@@ -9,8 +9,12 @@ describe 'iptables-patterns::frontend_permissive_ports' do
     expect(iptables).to have_rule('-i lo -j RETURN').with_chain('STANDARD-FIREWALL')
   end
 
-  it 'allows all ICMP traffic' do
+  it 'allows all ICMP traffic on ipv4' do
     expect(iptables).to have_rule('-p icmp -j RETURN').with_chain('STANDARD-FIREWALL')
+  end
+
+  it 'allows all ICMP traffic on ipv6' do
+    expect(iptables).to have_rule('-p ipv6-icmp -j RETURN').with_chain('STANDARD-FIREWALL')
   end
 
   it 'allows port 22 to be communicated with' do


### PR DESCRIPTION
The protocol name has changed in ipv6. ICMP is also needed for ipv6 TCP to work as well